### PR TITLE
Parsing and Persisting conciliation files

### DIFF
--- a/accounting_event.rb
+++ b/accounting_event.rb
@@ -1,0 +1,35 @@
+class AccountingEvent
+  attr_accessor :event_id,
+  :event_date,
+  :category_id,
+  :category,
+  :type_id,
+  :type,
+  :affiliation_code,
+  :gross_amount,
+  :net_amount,
+  :tax_amount,
+  :bank,
+  :agency,
+  :account,
+  :acquirer_adjust_code,
+  :acquirer_adjust_description
+
+  def initialize(event_id:, event_date:, category_id:, category:, type_id:, type:, affiliation_code:, gross_amount:, net_amount:, tax_amount:, bank:, agency:, account:, acquirer_adjust_code:, acquirer_adjust_description:)
+    @event_id = event_id
+    @event_date = event_date
+    @category_id = category_id
+    @category = category
+    @type_id = type_id
+    @type = type
+    @affiliation_code = affiliation_code
+    @gross_amount = gross_amount
+    @net_amount = net_amount
+    @tax_amount = tax_amount
+    @bank = bank
+    @agency = agency
+    @account = account
+    @acquirer_adjust_code = acquirer_adjust_code
+    @acquirer_adjust_description = acquirer_adjust_description
+  end
+end

--- a/acquirer_data.rb
+++ b/acquirer_data.rb
@@ -1,0 +1,60 @@
+class AcquirerData
+
+  attr_accessor :transaction_id,
+  :affiliation_code,
+  :summary_number,
+  :card_number,
+  :sale_date,
+  :transaction_gross_amount,
+  :transaction_tax_amount,
+  :transaction_net_amount,
+  :tax,
+  :tid,
+  :nsu,
+  :order_id,
+  :terminal_logic_number,
+  :capture_date,
+  :summary_identifier_number,
+  :installment_count,
+  :authorization_code,
+  :capture_method_id,
+  :capture_method_description,
+  :card_brand_id,
+  :card_brand,
+  :card_type_id,
+  :card_type,
+  :product_identifier_code,
+  :product_identifier_description
+
+    def initialize(transaction_id:, affiliation_code:, summary_number:, card_number:, sale_date:, transaction_gross_amount:, transaction_tax_amount:, transaction_net_amount:, tax:, tid:, nsu:, order_id:, terminal_logic_number:, capture_date:, summary_identifier_number:, installment_count:, authorization_code:, capture_method_id:, capture_method_description:,   card_brand_id:, card_brand:, card_type_id:, card_type:, product_identifier_code:, product_identifier_description:)
+      @transaction_id = transaction_id
+      @affiliation_code = affiliation_code
+      @summary_number = summary_number
+      @card_number = card_number
+      @sale_date = sale_date
+      @transaction_gross_amount = transaction_gross_amount
+      @transaction_tax_amount = transaction_tax_amount
+      @transaction_net_amount = transaction_net_amount
+      @tax = tax
+      @tid = tid
+      @nsu = nsu
+      @order_id = order_id
+      @terminal_logic_number = terminal_logic_number
+      @capture_date = capture_date
+      @summary_identifier_number = summary_identifier_number
+      @installment_count = installment_count
+      @authorization_code = authorization_code
+      @capture_method_id = capture_method_id
+      @capture_method_description = capture_method_description
+      @card_brand_id = card_brand_id
+      @card_brand = card_brand
+      @card_type_id = card_type_id
+      @card_type = card_type
+      @product_identifier_code = product_identifier_code
+      @product_identifier_description = product_identifier_description
+   end
+
+
+
+
+end

--- a/conciliated_transaction.rb
+++ b/conciliated_transaction.rb
@@ -1,0 +1,14 @@
+class ConciliatedTransaction
+
+attr_accessor :conciliation_type_id, :conciliation_type
+attr_accessor :sale_data, :acquirer_data, :accounting_events, :informational_events
+
+  def initialize(conciliation_type_id:, conciliation_type:)
+    @conciliation_type_id = conciliation_type_id
+    @conciliation_type = conciliation_type
+    @accounting_events = []
+    @informational_events = []
+
+ end
+
+end

--- a/conciliation_file.rb
+++ b/conciliation_file.rb
@@ -1,0 +1,24 @@
+class ConciliationFile
+
+  attr_accessor :merchant_id, :acquirer_id, :generationDate_time, :start_period, :end_period, :sequential_number, :processing_type_id, :processing_type, :version
+  attr_accessor :conciliated_transactions
+
+  def initialize(merchant_id:, acquirer_id:, generation_date_time:, start_period:, end_period:, sequential_number:, processing_type_id:, processing_type:, version:)
+    @merchant_id = merchant_id
+    @acquirer_id = acquirer_id
+    @generationDate_time = generationDate_time
+    @start_period = start_period
+    @end_period = end_period
+    @sequential_number = sequential_number
+    @processing_type_id = processing_type_id
+    @processing_type = processing_type
+    @version = version
+    @conciliated_transactions =[]
+
+    def find_transaction(value)
+      conciliated_transactions.find do |conciliated_transaction|
+        conciliated_transaction.sale_data.transaction_id == value
+    end
+  end
+end
+end

--- a/informational_event.rb
+++ b/informational_event.rb
@@ -1,0 +1,34 @@
+class InformationalEvent
+
+attr_accessor :event_id,
+:event_date,
+:category_id,
+:category,
+:type_id,
+:type,
+:affiliation_code,
+:transaction_installment,
+:gross_amount,
+:net_amount,
+:tax_amount,
+:bank,
+:agency,
+:account
+
+  def initialize(event_id:,event_date:,category_id:,category:,type_id:,type:,affiliation_code:,transaction_installment:,gross_amount:,net_amount:,tax_amount:,bank:,agency:,account:)
+    @event_id = event_id
+    @event_date = event_date
+    @category_id = category_id
+    @category = category
+    @type_id = type_id
+    @type = type
+    @affiliation_code = affiliation_code
+    @transaction_installment = transaction_installment
+    @gross_amount = gross_amount
+    @net_amount = net_amount
+    @tax_amount = tax_amount
+    @bank = bank
+    @agency = agency
+    @account = account
+  end
+end

--- a/parse.rb
+++ b/parse.rb
@@ -1,0 +1,8 @@
+load "parser.rb"
+
+begin
+puts Parser.parse("../cielo-2017-04-15.csv")
+rescue RuntimeError => e
+  puts e.message
+  puts e.backtrace
+end

--- a/parser.rb
+++ b/parser.rb
@@ -1,0 +1,57 @@
+load "conciliation_file.rb"
+load "conciliated_transaction.rb"
+load "sale_data.rb"
+load "acquirer_data.rb"
+load "accounting_event.rb"
+load "informational_event.rb"
+
+class Parser
+  def self.parse(file)
+    conciliation_file = nil
+    conciliated_transaction = nil
+
+    File.readlines(file).each do |line|
+      values = line.split(";")
+
+      case values[0]
+        when "1" then conciliation_file = initialize_conciliation_file(values)
+        when "2" then conciliated_transaction = initialize_conciliated_transaction(values, conciliation_file)
+        when "3" then initialize_sale_data(values, conciliated_transaction)
+        when "4" then initialize_acquirer_data(values, conciliated_transaction)
+        when "5" then initialize_accounting_event(values, conciliated_transaction)
+        when "6" then initialize_informational_event(values, conciliated_transaction)
+      end
+    end
+
+    conciliation_file
+  end
+  def self.initialize_conciliation_file(values)
+    ConciliationFile.new(merchant_id: values[1], acquirer_id:values[2], generation_date_time:values[3], start_period:values[4], end_period:values[5], sequential_number:values[6], processing_type_id:values[6], processing_type:values[7], version:values[8])
+  end
+  def self.initialize_conciliated_transaction(values, conciliation_file)
+    conciliated_transaction = ConciliatedTransaction.new(conciliation_type_id: values[1], conciliation_type: values[2])
+    conciliation_file.conciliated_transactions.push(conciliated_transaction)
+    conciliated_transaction
+  end
+  def self.initialize_sale_data(values, conciliated_transaction)
+    sale_data = SaleData.new(transaction_id: values[1], external_id: values[2], branch_id: values[3], affiliation_code: values[4], order_id: values[5], authorization_code: values[6], sale_date: values[7], capture_date: values[8], transaction_amount: values[9], installment_count: values[10], customer_name: values[11], customer_document: values[12], card_number: values[13], tid: values[14], nsu: values[15], payment_method_name: values[16])
+    if !sale_data.valid?
+      raise RuntimeError.new(values)
+    end
+    conciliated_transaction.sale_data = sale_data
+  end
+  def self.initialize_acquirer_data(values, conciliated_transaction)
+    acquirer_data = AcquirerData.new(transaction_id: values[1], affiliation_code: values[2], summary_number: values[3], card_number: values[4], sale_date: values[5], transaction_gross_amount: values[6], transaction_tax_amount: values[7], transaction_net_amount: values[8], tax: values[9], tid: values[10], nsu: values[11], order_id: values[12], terminal_logic_number: values[13], capture_date: values[14], summary_identifier_number: values[15], installment_count: values[16], authorization_code: values[17], capture_method_id: values[18], capture_method_description: values[19], card_brand_id: values[20], card_brand:values[21], card_type_id:values[22], card_type: values[23], product_identifier_code: values[24], product_identifier_description: values[25])
+    conciliated_transaction.acquirer_data = acquirer_data
+  end
+  def self.initialize_accounting_event(values, conciliated_transaction)
+    accounting_event = AccountingEvent.new(event_id: values[1], event_date: values[2], category_id: values[3], category: values[4], type_id: values[5], type: values[6], affiliation_code: values[7], gross_amount: values[8], net_amount: values[9], tax_amount: values[10], bank: values[11], agency: values[12], account: values[13], acquirer_adjust_code: values[14], acquirer_adjust_description: values[15])
+    conciliated_transaction.accounting_events.push(accounting_event)
+    accounting_event
+  end
+  def self.initialize_informational_event(values, conciliated_transaction)
+    informational_event = InformationalEvent.new(event_id: values[1],event_date: values[2],category_id: values[3],category: values[4],type_id: values[5],type: values[6],affiliation_code: values[7],transaction_installment: values[8], gross_amount: values[9], net_amount: values[10], tax_amount: values[11], bank: values[12], agency: values[13], account: values[14])
+    conciliated_transaction.informational_events.push(informational_event)
+    informational_event
+  end
+end

--- a/sale_data.rb
+++ b/sale_data.rb
@@ -1,0 +1,47 @@
+class SaleData
+
+  attr_accessor :transaction_id,
+  :external_id,
+  :branch_id,
+  :affiliation_code,
+  :order_id,
+  :authorization_code,
+  :sale_date,
+  :capture_date,
+  :transaction_amount,
+  :installment_count,
+  :customer_name,
+  :customer_document,
+  :card_number,
+  :tid,
+  :nsu,
+  :payment_method_name
+
+  def initialize(transaction_id:, external_id:, branch_id:, affiliation_code:, order_id:, authorization_code:, sale_date:, capture_date:, transaction_amount:, installment_count:, customer_name:, customer_document:, card_number:, tid:, nsu:, payment_method_name:)
+    @transaction_id = transaction_id
+    @external_id = external_id
+    @branch_id = branch_id
+    @affiliation_code = affiliation_code
+    @order_id = order_id
+    @authorization_code = authorization_code
+    @sale_date = sale_date
+    @capture_date = capture_date
+    @transaction_amount = transaction_amount
+    @installment_count = installment_count
+    @customer_name = customer_name
+    @customer_document = customer_document
+    @card_number = card_number
+    @tid = tid
+    @nsu = nsu
+    @payment_method_name = payment_method_name
+  end
+
+  def values
+    [transaction_id, external_id, branch_id, affiliation_code, order_id, authorization_code, sale_date, capture_date, transaction_amount, installment_count, customer_name, customer_document, card_number, tid, nsu, payment_method_name]
+  end
+  def valid?
+    values.all? do |value|
+      value != nil
+    end
+  end
+end


### PR DESCRIPTION
We have an integration with a payment partner and it provides us with a reconciliation file in CSV format. We need to read the contents of the file and guarantee its integrity.

This PR inserts the following functions:

- Read reconciliation file
- Save content in memory
- Find details and validate a transaction without saledata